### PR TITLE
fix: correctly assigning AID

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -395,7 +395,7 @@ const MainComponent = () => {
                               setStatus('Connecting')
                               return
                             } else {
-                              setAids(_ids)
+                              setAids(_ids.aids)
                               setActiveStep(prevStep => prevStep + 1)
                             }
                           }


### PR DESCRIPTION
We could not assign _id (of type object) with setAids as it only accepts an array.

Solution: extract the array attribute and assign it correctly